### PR TITLE
Fix javadoc

### DIFF
--- a/src/main/java/metatype/astar/AstarPathfinder.java
+++ b/src/main/java/metatype/astar/AstarPathfinder.java
@@ -12,7 +12,7 @@ import java.util.Set;
  * Uses an heuristic estimate to improve the routing speed and prune the search
  * space.
  * 
- * @see http://en.wikipedia.org/wiki/A*_search_algorithm
+ * @see <a href="http://en.wikipedia.org/wiki/A*_search_algorithm">A* search algorithm</a>
  * 
  * @author metatype
  * 


### PR DESCRIPTION
Javadoc errors are considered a compile error by default since Java 8 therefore fixing the `@see` reference is necessary for building your project without additional configuration.