### PR TITLE
Do not require `Graph.setWeight`

### DIFF
--- a/src/main/java/metatype/astar/Graph.java
+++ b/src/main/java/metatype/astar/Graph.java
@@ -66,14 +66,4 @@ public interface Graph<V, E> {
    * @return the edge weight
    */
   double getWeight(E edge);
-
-  /**
-   * Sets the edge weight.
-   * 
-   * @param edge
-   *          the edge
-   * @param w
-   *          the weight
-   */
-  void setWeight(E edge, double w);
 }

--- a/src/test/java/metatype/astar/SimpleGraph.java
+++ b/src/test/java/metatype/astar/SimpleGraph.java
@@ -88,7 +88,14 @@ public class SimpleGraph implements Graph<Vertex, Edge> {
     return edge.weight;
   }
   
-  @Override
+  /**
+   * Sets the edge weight.
+   * 
+   * @param edge
+   *          the edge
+   * @param w
+   *          the weight
+   */
   public void setWeight(Edge edge, double w) {
     edge.weight = w;
   }


### PR DESCRIPTION
Providing a `Graph.setWeight` method implies an modifiable `Graph`.
